### PR TITLE
prevent publishing package when branches are created

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,8 @@ name: Publish packages
 
 on:
   create:
-    tags:
-      - v*
-    branches: []
+    branches:
+      - refs/tags/@udondan/v*
 
 jobs:
   build:


### PR DESCRIPTION
Currently the action for publishing artifacts is triggered by new branches, not only by new tags.

https://github.community/t5/GitHub-Actions/How-to-run-GitHub-Actions-Workflow-only-for-new-tags/td-p/29413